### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP server that provides structured access to [Aster DEX](https://www.asterdex.com/en) market data—covering candlesticks, order books, trades, and funding rates.
 
+<a href="https://glama.ai/mcp/servers/@kukapay/aster-info-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/aster-info-mcp/badge" alt="aster-info-mcp MCP server" />
+</a>
+
 ![GitHub License](https://img.shields.io/github/license/kukapay/aster-info-mcp) 
 ![Python Version](https://img.shields.io/badge/python-3.10%2B-blue)
 ![Status](https://img.shields.io/badge/status-active-brightgreen.svg)


### PR DESCRIPTION
This PR adds a badge for the [aster-info-mcp](https://glama.ai/mcp/servers/@kukapay/aster-info-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kukapay/aster-info-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kukapay/aster-info-mcp/badge" alt="aster-info-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.